### PR TITLE
[#2] Setup CI pipeline

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -35,7 +35,7 @@ func migrateDB(db *gorm.DB) {
 
 	err = goose.Up(sqlDB, "database/migrations", goose.WithAllowMissing())
 	if err != nil {
-		log.Println(err)
+		log.Errorf("Failed to migrate database: %v", err)
 	}
 
 	log.Println("Migrated database successfully.")

--- a/database/database.go
+++ b/database/database.go
@@ -35,7 +35,7 @@ func migrateDB(db *gorm.DB) {
 
 	err = goose.Up(sqlDB, "database/migrations", goose.WithAllowMissing())
 	if err != nil {
-		log.Fatalf("Failed to migrate database: %v", err)
+		log.Println(err)
 	}
 
 	log.Println("Migrated database successfully.")


### PR DESCRIPTION
- Close #2

## What happened 👀

- Change to print log instead of print a fatal error when migrating

## Insight 📝

- When there is no migration file `goose.Up(sqlDB, "database/migrations", goose.WithAllowMissing())` will return an error, but it's a string so it's good to just print the log rather than throw a fatal error here

## Proof Of Work 📹

CI successfully
